### PR TITLE
Change pandoc --latex-engine command to --pdf-engine

### DIFF
--- a/mkdocs_mk2pdf_plugin/renderer.py
+++ b/mkdocs_mk2pdf_plugin/renderer.py
@@ -9,9 +9,9 @@ class Renderer(object):
 
     def write_pdf(self,  mk_filename: str, pdf_filename: str):
         if os.path.isfile(self.template) and os.path.exists(self.template):
-            os.system('pandoc --latex-engine=xelatex --template=%s  %s -o %s'%(self.template,mk_filename,pdf_filename))
+            os.system('pandoc --pdf-engine=xelatex --template=%s  %s -o %s'%(self.template,mk_filename,pdf_filename))
         else:
-            os.system('pandoc --latex-engine=xelatex %s -o %s'%(mk_filename,pdf_filename))
+            os.system('pandoc --pdf-engine=xelatex %s -o %s'%(mk_filename,pdf_filename))
 
     def add_doc(self, rel_path: str, abs_path: str):
         try:


### PR DESCRIPTION
Pull request regardin #4 

pandoc realeased a breaking change in 2017: Rename --latex-engine to --pdf-engine, and --latex-engine-opt to --pdf-engine-opt.